### PR TITLE
Fix missing ID when detecting intros

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/QueueManager.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/QueueManager.cs
@@ -71,7 +71,10 @@ public class QueueManager
 
             try
             {
-                QueueLibraryContents(folder.ItemId);
+                foreach (var location in folder.Locations)
+                {
+                    QueueLibraryContents(_libraryManager.FindByPath(location, true).Id);
+                }
             }
             catch (Exception ex)
             {
@@ -126,14 +129,14 @@ public class QueueManager
         }
     }
 
-    private void QueueLibraryContents(string rawId)
+    private void QueueLibraryContents(Guid id)
     {
         _logger.LogDebug("Constructing anonymous internal query");
 
         var query = new InternalItemsQuery()
         {
             // Order by series name, season, and then episode number so that status updates are logged in order
-            ParentId = Guid.Parse(rawId),
+            ParentId = id,
             OrderBy = new[]
             {
                 ("SeriesSortName", SortOrder.Ascending),

--- a/ConfusedPolarBear.Plugin.IntroSkipper/QueueManager.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/QueueManager.cs
@@ -65,9 +65,8 @@ public class QueueManager
             }
 
             _logger.LogInformation(
-                "Running enqueue of items in library {Name} ({ItemId})",
-                folder.Name,
-                folder.ItemId);
+                "Running enqueue of items in library {Name}",
+                folder.Name);
 
             try
             {


### PR DESCRIPTION
In the latest jellyfin version, the detection tasks both fail with
```
ConfusedPolarBear.Plugin.IntroSkipper.QueueManager: Failed to enqueue items from library "<library>": "System.ArgumentNullException: Value cannot be null. (Parameter 'input')
   at System.Guid.Parse(String input)
   at ConfusedPolarBear.Plugin.IntroSkipper.QueueManager.QueueLibraryContents(String rawId)
   at ConfusedPolarBear.Plugin.IntroSkipper.QueueManager.GetMediaItems()"
```
Apparently, the virtual folders returned by `_libraryManager.GetVirtualFolders()` no longer have their `ItemId` set. However, if I'm right, (which I might not be, I haven't really used this api before,) this is replaced by the ids of the virtual folder's locations. This gives a non-null ID and it seems to work together with the rest of the code, I see multiple series and seasons queued.

Also, there is now no need to parse the Guid from a string, we can just use the original Guid objects.